### PR TITLE
set request headers

### DIFF
--- a/driver-simulator/api.js
+++ b/driver-simulator/api.js
@@ -29,13 +29,23 @@ function deregisterVehicle(vehicleId) {
 }
 
 function request(path, method, body, cb) {
+  const data = JSON.stringify(body)
+
   const req = http.request(
-    { hostname: API_HOST, port: API_PORT, path: path, method: method },
+    { hostname: API_HOST,
+      port: API_PORT,
+      path: path,
+      method: method,
+      headers: {
+        "Content-Type": "application/json",
+        "Content-Length": Buffer.byteLength(data)
+      }
+    },
     cb
   );
 
   if (body) {
-    req.write(JSON.stringify(body));
+    req.write(data);
   }
 
   req.on("error", error => {

--- a/driver-simulator/api.test.js
+++ b/driver-simulator/api.test.js
@@ -17,6 +17,8 @@ beforeEach(() => {
 });
 
 describe("registerVehicle", () => {
+  const data = JSON.stringify({ id: vehicleId });
+
   beforeEach(() => api.registerVehicle(vehicleId));
 
   it("should make a POST request to /vehicles", () => {
@@ -25,7 +27,11 @@ describe("registerVehicle", () => {
         hostname: "localhost",
         port: "4567",
         path: `/vehicles`,
-        method: "POST"
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "Content-Length": Buffer.byteLength(data)
+        }
       },
       expect.any(Function)
     );
@@ -34,7 +40,7 @@ describe("registerVehicle", () => {
   });
 
   it("should write the vehicle id in the request body", () => {
-    expect(req.write).toBeCalledWith(JSON.stringify({ id: vehicleId }));
+    expect(req.write).toBeCalledWith(data);
   });
 });
 
@@ -43,6 +49,7 @@ describe("updateVehicleLocation", () => {
   const lat = 52.5128;
   const lng = 13.3209;
   const RealDate = Date;
+  const data = JSON.stringify({ lat, lng, at });
 
   function mockDate(isoDate) {
     global.Date = class extends RealDate {
@@ -65,7 +72,11 @@ describe("updateVehicleLocation", () => {
         hostname: "localhost",
         port: "4567",
         path: `/vehicles/${vehicleId}/locations`,
-        method: "POST"
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "Content-Length": Buffer.byteLength(data)
+        }
       },
       expect.any(Function)
     );
@@ -74,11 +85,13 @@ describe("updateVehicleLocation", () => {
   });
 
   it("should write the vehicle location in the request body", () => {
-    expect(req.write).toBeCalledWith(JSON.stringify({ lat, lng, at }));
+    expect(req.write).toBeCalledWith(data);
   });
 });
 
 describe("deregisterVehicle", () => {
+  const data = JSON.stringify(null);
+
   beforeEach(() => api.deregisterVehicle(vehicleId));
 
   it("should make a DELETE request to /vehicles/vehicleId", () => {
@@ -87,7 +100,11 @@ describe("deregisterVehicle", () => {
         hostname: "localhost",
         port: "4567",
         path: `/vehicles/${vehicleId}`,
-        method: "DELETE"
+        method: "DELETE",
+        headers: {
+          "Content-Type": "application/json",
+          "Content-Length": Buffer.byteLength(data)
+        }
       },
       expect.any(Function)
     );


### PR DESCRIPTION
Hi door2door team,

While doing this code challenge I realised that there is no `"Content-Type": "application/json"` header set for driver-simulator requests. This caused some problems within my rails 5 app regarding the params. I will attach some screenshots to show the request.
Instead of fixing this within my app I would prefer to adjust the request. Feel free to ad your thoughts.

**Before change:**
![vehicle_post_before](https://user-images.githubusercontent.com/6471346/32019465-96f58212-b9cd-11e7-8a10-8e4d6e5b3a99.png)

**After change:**
![vehicle_post_after](https://user-images.githubusercontent.com/6471346/32019471-9fdfc23e-b9cd-11e7-90f9-c2396a60e011.png)
