### PR TITLE
Avoid ambiguity on what is a valid position data

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -69,7 +69,7 @@ No schema is prescribed for this broadcast, but the mechanism and schema you cho
 
 If a vehicle has exited the "city boundaries", the system should disregard any GPS emissions from that vehicle. The city boundary is currently assumed to be a 3.5km radius around door2door's office which is located at latitude 52.53 and longitude 13.403.
 
-All valid position data received must be stored somewhere for future analysis and consumption by the door2door data science team.
+All valid position data, that are inside the "city boundaries", must be stored somewhere for future analysis and consumption by the door2door data science team.
 
 ## Technical assumptions
 

--- a/fullstack/README.md
+++ b/fullstack/README.md
@@ -71,7 +71,7 @@ We expect your visualization to be accessible via a web browser. It only needs t
 
 If a vehicle has exited the "city boundaries", the system should disregard any GPS emissions from that vehicle. The city boundary is currently assumed to be a 3.5km radius around door2door's office which is located at latitude 52.53 and longitude 13.403.
 
-All valid position data received must be stored somewhere for future analysis and consumption by the door2door data science team.
+All valid position data, that are inside the "city boundaries", must be stored somewhere for future analysis and consumption by the door2door data science team.
 
 ## Technical assumptions
 


### PR DESCRIPTION
In this pull request, we are changing the copy of the code challenge to avoid the ambiguity of what position data should be stored for further analyses.

This sentence confuses candidates that are not sure if a valid position data is just a valid combination of latitude and longitude, or if they also must be inside the "city boundaries".