### PR TITLE
Request that candidates only send solutions via ZIP file

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -90,7 +90,7 @@ A containerized solution is a requirement for senior position applicants.
 
 ## Delivery of your solution
 
-Please deliver your solution to us as a publicly accessible git repository, or in a ZIP file. The repository should contain full instructions for us to run the solution on our own machines.
+Please deliver your solution to us by email in an attached ZIP file. The repository should contain full instructions for us to run the solution on our own machines.
 
 If you are able to publicly host the solution somewhere (e.g. Heroku, AWS), this would be a great bonus.
 

--- a/data/README.md
+++ b/data/README.md
@@ -93,7 +93,7 @@ When an operator adds or removes an operation period, the `on` field will be set
 
 ## Delivery of your solution
 
-Please deliver your solution to us in a git repository or in a ZIP file. You must provide complete instructions for us to run the solution on our own machines. If you choose to use git, make sure the reviewers will be able to access your repository.
+Please deliver your solution to us by email in an attached ZIP file. You must provide complete instructions for us to run the solution on our own machines. If you choose to use git, make sure the reviewers will be able to access your repository.
 
 With one of the methods of deliver above, you may optionally host the solution on the Internet (e.g. Heroku, AWS). Make sure to provide access to door2door's reviewers.
 

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -25,7 +25,7 @@ The following points are optional features that you may choose to implement, but
 
 ## Delivery of your solution
 
-Please deliver your solution to us as a publicly accessible git repository, or in a ZIP file. The repository should contain full instructions for us to build and run the project.
+Please deliver your solution to us by email in an attached ZIP file. The repository should contain full instructions for us to build and run the project.
 
 ## Reviewing
 

--- a/fullstack/README.md
+++ b/fullstack/README.md
@@ -90,7 +90,7 @@ A containerized solution is a requirement for senior position applicants.
 
 ## Delivery of your solution
 
-Please deliver your solution to us as a publicly accessible git repository, or in a ZIP file. The repository should contain full instructions for us to run the solution on our own machines.
+Please deliver your solution to us by email in an attached ZIP file. The repository should contain full instructions for us to run the solution on our own machines.
 
 If you are able to publicly host the solution somewhere (e.g. Heroku, AWS), this would be a great bonus.
 

--- a/mobile/README.MD
+++ b/mobile/README.MD
@@ -26,7 +26,7 @@ The following points are optional features that you may choose to implement, but
 
 ## Delivery of your solution
 
-Please deliver your solution to us as a publicly accessible git repository, or in a ZIP file. The repository should contain full instructions for us to build and run the project.
+Please deliver your solution to us by email in an attached ZIP file. The repository should contain full instructions for us to build and run the project.
 
 ## Reviewing
 


### PR DESCRIPTION
Sometimes publicly accessible repos are left available online and can be found via search engines. To reduce the risk of this happening, we will request candidates only send solutions via ZIP file from now on.